### PR TITLE
FIRMWARE: add BLE MAC Adress in BLE Device name

### DIFF
--- a/firmware/RCj_comm_module/ble.cpp
+++ b/firmware/RCj_comm_module/ble.cpp
@@ -30,7 +30,7 @@ static QueueHandle_t ble_msg_queue;
 
 // Callbacks
 class MyServerCallbacks: public BLEServerCallbacks {
-    void onConnect(BLEServer* pServer, esp_ble_gatts_cb_param_t *param) override {
+    void onConnect(BLEServer* pServer) override {
         //Serial.println("Client connected");
         device_connected = true;
         //stm_set_state(STM_PLAY);

--- a/firmware/RCj_comm_module/definitions.h
+++ b/firmware/RCj_comm_module/definitions.h
@@ -11,7 +11,7 @@
 #define UART_SPEED      115200
 
 // BLE
-#define BLE_NAME            "RCJ-soccer_module"
+#define BLE_NAME            "RCJs-m_" + BLE_MAC_to_string()
 #define BLE_DATA_MAX_LENGTH 10
 #define BLE_QUEUE_MAX_SIZE  5
 

--- a/update.md
+++ b/update.md
@@ -1,0 +1,39 @@
+# How to update
+
+### NO WARRANTY FOR DESTROYED HARDWARE
+Be careful: USB ports provide 5 V. Incorrect wiring may damage your module or PC. Proceed only if you understand the risks. Use a USB breakout board if unsure.
+
+## Requirements
+- Communication module
+- Arduino IDE(2)
+- USB Cable that can be cut in half OR USB Breakout board
+- Jumper cables female OR Jumper cables male with a breadboard
+
+## Prepare your hardware
+1. If using USB Cable: cut it in half and keep the half that can connects to your PC
+2. If using female jumper cables: cut two cables in half and solder them to your usb cable OR your breakout board
+3. Connect your module (Connect GND always first and disconnect last):
+   1. USB GND (black) -> Module GND
+   2. USB VCC (red) -> Module BAT+
+   3. USB D+ (green) -> Module D+
+   4. USB D- (white) -> Module D-
+   
+   NOTE:
+
+    If your computer does not detect the device within ~10 seconds, swap D+ and D-.
+   
+    On some cables colors may differ - verify with a multimeter if possible.
+
+4. (Connect your USB cable / breakout board with your PC)
+
+## Prepare your PC
+0. Install the Arduino IDE (2)
+1. Open the Board manager `Tools > Board > Board Manager`
+2. Search for `esp32`
+3. Install `esp32 by Espressif Systems` in Version 3.2.2
+4. Open the `*.ino` file
+5. Connect your module
+6. Under `Tools > Board > esp32` select `ESP32C6 Dev Module`
+7. Under `Tools > Port` select the port where your COM Module is connected
+8. Under `Sketch` select `Upload` to program the new firmware on your COM Module
+9. DONE


### PR DESCRIPTION
I modified the firmware of the communication modules to also contain the mac addresses in the BLE Device name. Sadly, I needed to change the prefix to someting shorter and went with RCJs-m_ instead of the previous RCJ-soccer_module. This was necessary due to a limitation on how long the name can be, to be shown properly.

Additionally I removed the app as it is now in its own repo and added instructions on how to update the modules