### PR TITLE
Mirror play stop status to USB serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ cat /dev/ttyACM0
 ```
 
 The onboard buzzer gives a short confirmation beep whenever the referee app changes the match state.
+The RGB status LED is green in PLAY and red when the robot output is stopped.
 
 ### Power it
 
@@ -146,7 +147,7 @@ Check the [open issues](https://github.com/robocup-junior/soccer-communication-m
 ## 🔭 Currently working on
 
 - Robot-to-robot communication
-- RGB LED feedback
+- Additional RGB LED feedback patterns
 
 ## 🏆 Hall of fame
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cat /dev/ttyACM0
 ```
 
 The onboard buzzer gives a short confirmation beep whenever the referee app changes the match state.
-The RGB status LED is green in PLAY and red when the robot output is stopped.
+The RGB status LED is dimmed green in PLAY and dimmed red when the robot output is stopped.
 
 ### Power it
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ stty -F /dev/ttyACM0 115200 raw -echo
 cat /dev/ttyACM0
 ```
 
+The onboard buzzer gives a short confirmation beep whenever the referee app changes the match state.
+
 ### Power it
 
 Power the module **directly from the robot battery** so it stays alive for the whole match — even when the robot is switched off or removed from the field — to keep a stable BLE connection.
@@ -144,7 +146,7 @@ Check the [open issues](https://github.com/robocup-junior/soccer-communication-m
 ## 🔭 Currently working on
 
 - Robot-to-robot communication
-- RGB LED & buzzer feedback
+- RGB LED feedback
 
 ## 🏆 Hall of fame
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <img src="./.readme_images/3D_PCB1_2026-05-21%20v41.png?raw=true" alt="RCJ Soccer communication module" width="600">
 </p>
 
-A small referee-to-robot interface for **RoboCupJunior Soccer**. A referee controls the module over **Bluetooth Low Energy (BLE)** from the mobile app, and the module relays the live match state — **PLAY, STOP, penalty, half-time, game over** — to the robot over simple digital outputs or UART.
+A small referee-to-robot interface for **RoboCupJunior Soccer**. A referee controls the module over **Bluetooth Low Energy (BLE)** from the mobile app, and the module relays the live match state — **PLAY, STOP, penalty, half-time, game over** — to the robot or host controller over simple digital outputs, UART, or USB serial.
 
 The current module (board **V7 / 2026**) is built around an **ESP32-C5** and includes an OLED display, three buttons, an RGB LED, a buzzer, a USB-C port for power & flashing, and an on-board **supercapacitor** backup. It does **not** count toward the robot weight limit.
 
@@ -45,14 +45,24 @@ The app's source code lives in its own repository: **[robocup-junior/soccer-refe
 
 ### Read the start/stop signal (pick one method)
 
-The robot must respond to the start/stop signal for the entire game. Connect **one** of the following to a digital input and react whenever the state changes:
+The robot must respond to the start/stop signal for the entire game. Use **one** of the following methods and react whenever the state changes:
 
 | Method         | Pin                            | PLAY / GO        | STOP        |
 |----------------|--------------------------------|------------------|-------------|
 | **Output pin** | `OUT1` or `OUT2`               | **3.3 V** (HIGH) | **0 V** (LOW) |
 | **UART**       | `TX0` (UART0 on the U3 header) | sends `PLAY`     | sends `STOP` |
+| **USB serial** | USB-C                          | sends `PLAY`     | sends `STOP` |
 
 Both outputs carry the same 3.3 V logic-level signal. For 5 V robot inputs, add a level shifter before the robot. Always share **GND** with the robot controller — never connect VIN to a robot GPIO or to the 3.3 V pin.
+
+For a Raspberry Pi or another USB host, connect the module's USB-C port to the host's USB-A port. The ESP32-C5 enumerates as a serial device, typically `/dev/ttyACM0`, and prints one line (`PLAY` or `STOP`) whenever the referee app changes the match state.
+
+On Linux, you can check the USB serial output with:
+
+```sh
+stty -F /dev/ttyACM0 115200 raw -echo
+cat /dev/ttyACM0
+```
 
 ### Power it
 

--- a/docs/ai/00_project_overview.md
+++ b/docs/ai/00_project_overview.md
@@ -52,6 +52,7 @@ ble_processing.cpp  ble_msg_processing()  ── dispatch by msg_id ──►
       ▼
 state_machine.cpp  stm_update()
       ├─ update_output_satet(): OUTPUT1/OUTPUT2 GPIO HIGH (play) or LOW (stop)
+      ├─ buzzer_notify_state_change(): short IO26 beep for match-state changes
       └─ display_screen_*(): render current screen
       │
       ▼
@@ -92,13 +93,14 @@ delta vs the old code path that is implemented is:
   (commit `ca23261` "Improve BLE command latency and resilience").
 - A self-penalty request via double-press (commit `e423b0d`).
 
-## Planned hardware features (NOT implemented yet)
+## Planned hardware features
 
-These are on the board (confirmed in the V7 schematic) but have **no firmware support yet**;
-pins are now known (see [05_hardware_mapping.md](05_hardware_mapping.md)):
+These are on the board (confirmed in the V7 schematic); pins are known (see
+[05_hardware_mapping.md](05_hardware_mapping.md)):
 
 - **RGB LED** — discrete common-cathode, active-high: R=IO27, G=IO24, B=IO23 (470 Ω each).
-- **Buzzer** — passive 2.7 kHz via NPN Q1 on **IO26** (pin 27); needs PWM tone.
+- **Buzzer** — passive 2.7 kHz via NPN Q1 on **IO26** (pin 27); firmware now plays a short
+  PWM tone on match-state changes.
 - **Supercapacitor backup** — 15 F (C1); hardware ride-through, no firmware action required.
 - **Third button** B3 = **IO6** (SW2) — firmware currently wires only two buttons
   (`BUTTON_GPIO`=IO10/B1, `BUTTON2_GPIO`=IO7/B2).

--- a/docs/ai/00_project_overview.md
+++ b/docs/ai/00_project_overview.md
@@ -52,6 +52,7 @@ ble_processing.cpp  ble_msg_processing()  ── dispatch by msg_id ──►
       ▼
 state_machine.cpp  stm_update()
       ├─ update_output_satet(): OUTPUT1/OUTPUT2 GPIO HIGH (play) or LOW (stop)
+      ├─ status_led_set_play(): RGB LED green for play, red for stopped output
       ├─ buzzer_notify_state_change(): short IO26 beep for match-state changes
       └─ display_screen_*(): render current screen
       │
@@ -98,7 +99,8 @@ delta vs the old code path that is implemented is:
 These are on the board (confirmed in the V7 schematic); pins are known (see
 [05_hardware_mapping.md](05_hardware_mapping.md)):
 
-- **RGB LED** — discrete common-cathode, active-high: R=IO27, G=IO24, B=IO23 (470 Ω each).
+- **RGB LED** — discrete common-cathode, active-high: R=IO27, G=IO24, B=IO23 (470 Ω each);
+  firmware now shows green for PLAY and red for stopped robot output.
 - **Buzzer** — passive 2.7 kHz via NPN Q1 on **IO26** (pin 27); firmware now plays a short
   PWM tone on match-state changes.
 - **Supercapacitor backup** — 15 F (C1); hardware ride-through, no firmware action required.

--- a/docs/ai/00_project_overview.md
+++ b/docs/ai/00_project_overview.md
@@ -52,7 +52,7 @@ ble_processing.cpp  ble_msg_processing()  ── dispatch by msg_id ──►
       ▼
 state_machine.cpp  stm_update()
       ├─ update_output_satet(): OUTPUT1/OUTPUT2 GPIO HIGH (play) or LOW (stop)
-      ├─ status_led_set_play(): RGB LED green for play, red for stopped output
+      ├─ status_led_set_play(): dimmed RGB LED green for play, red for stopped output
       ├─ buzzer_notify_state_change(): short IO26 beep for match-state changes
       └─ display_screen_*(): render current screen
       │
@@ -100,7 +100,7 @@ These are on the board (confirmed in the V7 schematic); pins are known (see
 [05_hardware_mapping.md](05_hardware_mapping.md)):
 
 - **RGB LED** — discrete common-cathode, active-high: R=IO27, G=IO24, B=IO23 (470 Ω each);
-  firmware now shows green for PLAY and red for stopped robot output.
+  firmware now shows 50% PWM green for PLAY and 50% PWM red for stopped robot output.
 - **Buzzer** — passive 2.7 kHz via NPN Q1 on **IO26** (pin 27); firmware now plays a short
   PWM tone on match-state changes.
 - **Supercapacitor backup** — 15 F (C1); hardware ride-through, no firmware action required.

--- a/docs/ai/02_firmware_architecture.md
+++ b/docs/ai/02_firmware_architecture.md
@@ -11,6 +11,7 @@
 | BLE processing | `ble_processing.cpp` / `ble_processing.h` | `ble_msg_t`, `ble_msg_id` enum, RTOS queue, command dispatch |
 | State machine | `state_machine.cpp` / `state_machine.h` | `stm_states`, output-pin control, timer |
 | Display | `display.cpp` / `display.h` | SSD1306 rendering per state |
+| Buzzer | `buzzer.cpp` / `buzzer.h` | Non-blocking 2.7 kHz beep on match-state changes |
 | Functions/util | `functions.cpp` / `functions.h` | MAC string, score/indicator globals, GPIO init, button handling |
 | Assets | `fonts.h`, `images.h` | OLED fonts and boot logo (`RC_logo`) |
 
@@ -39,7 +40,7 @@ extern "C" void app_main(void) { initArduino(); module_setup(); while (true) { m
 
 1. `Serial.begin(UART_SPEED)` — `UART_SPEED = 115200`. Used for debug prints only.
 2. `display_init()` — `SSD1306 display(0x3c, I2C_SDA_GPIO, I2C_SCL_GPIO)`, `display.init()`.
-3. `module_init_gpios()` — `OUTPUT1_GPIO`/`OUTPUT2_GPIO` as `OUTPUT`; `BUTTON_GPIO`/`BUTTON2_GPIO` as `INPUT` (no explicit pull configured — see hardware doc).
+3. `module_init_gpios()` — `OUTPUT1_GPIO`/`OUTPUT2_GPIO` as `OUTPUT`; `BUTTON_GPIO`/`BUTTON2_GPIO` as `INPUT` (no explicit pull configured — see hardware doc); initializes the IO26 passive buzzer.
 4. `stm_init()` — current state stays `STM_INIT`; sets timer to `660000 ms` (see below / [04](04_state_machine.md)).
 5. `ble_start_server()` — creates the message queue, BLE device, server, service, RX/TX characteristics, and starts advertising.
 
@@ -50,7 +51,8 @@ extern "C" void app_main(void) { initArduino(); module_setup(); while (true) { m
 1. **`ble_msg_processing()`** — pops at most **one** message from the queue (`xQueueReceive`
    with timeout `0`) and dispatches it. Non-blocking; returns immediately if empty.
 2. **`stm_update()`** — runs the current state's handler and, on a state change, updates
-   the output pins.
+   the output pins and starts a short buzzer tone for match states. It also services the
+   non-blocking buzzer timeout.
 3. **`check_disconnect_button()`** — long-press (`DISCONNECT_HOLD_TIME = 5000 ms`) on
    `BUTTON_GPIO` triggers `ble_disconnect()`.
 4. **`check_penalty_button()`** — double-press on `BUTTON_GPIO` **or** `BUTTON2_GPIO`
@@ -90,6 +92,7 @@ but is worth noting for any future hardening.
 | `state_changed` | `state_machine.cpp` | One-shot flag: forces re-render + output update next `stm_update()` |
 | `robot_play` | `state_machine.cpp` | Drives `OUTPUT1/2` HIGH/LOW |
 | `timer_stop` | `state_machine.cpp` | `millis()` deadline for penalty/halftime countdown |
+| `buzzer_active`, `buzzer_stop_time` | `buzzer.cpp` | Non-blocking buzzer timeout state |
 | `device_connected` | `ble.cpp` | BLE connection state |
 | `module_indicator` | `functions.cpp` | 2-char team/robot label (default `"--"`) |
 | `my_score`, `opponent_score` | `functions.cpp` | Scoreboard values |

--- a/docs/ai/02_firmware_architecture.md
+++ b/docs/ai/02_firmware_architecture.md
@@ -97,10 +97,12 @@ but is worth noting for any future hardening.
 ## Legacy UART / Serial behavior
 
 - `Serial.begin(115200)` is called at startup.
-- `update_output_satet()` (`state_machine.cpp:32,36`) prints `"PLAY"` / `"STOP"` to `Serial`
-  on every output change. **These are the only active serial prints in the firmware** — they
-  double as a UART status channel for robots that read the serial line instead of the OUT
-  pins.
+- `update_output_satet()` in `state_machine.cpp` prints `"PLAY"` / `"STOP"` through
+  `serial_status_println()` on every output change. That helper mirrors each line to
+  Arduino `Serial` (UART0 on U3) and the ESP32-C5 USB Serial/JTAG port (USB-C, typically
+  `/dev/ttyACM*` on Linux). **These are the only active serial status prints in the firmware**
+  and double as status channels for robots or Raspberry Pi hosts that read serial instead
+  of the OUT pins.
 - All other debug prints are **already commented out**: `ble.cpp:45,64,147,149`,
   `ble_processing.cpp:71`, `functions.cpp:107,121`. (Verified 2026-05-31.) The vendored
   `libraries/**/examples/*.ino` prints are not compiled; the OLED lib's `"[deprecated]"`
@@ -132,15 +134,14 @@ Verified against the generated build config (`build/config/sdkconfig.h`, 2026-05
 | Config | `sdkconfig.defaults` only | `sdkconfig.defaults` + `sdkconfig.debug` |
 | IDF/bootloader logs | OFF (`*_LOG_LEVEL_NONE`) | INFO |
 | IDF console route | UART0 | **USB-C** (`CONFIG_ESP_CONSOLE_USB_SERIAL_JTAG`) |
-| Arduino `Serial` (`PLAY`/`STOP`) | UART0 | UART0 (unchanged) |
+| Arduino `Serial` (`PLAY`/`STOP`) | UART0; mirrored to USB-C by `serial_status` | UART0; mirrored to USB-C by `serial_status` |
 | Built by | CI on every tag | local dev only |
 
 Debug build command:
 `idf.py -D SDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.debug" build flash monitor`
 (later defaults file wins on conflicting choices). This keeps the UART0 line free for the
 robot while a developer watches logs over USB-C. `Serial`'s `PLAY`/`STOP` stays on UART0 in
-both flavors; mirroring it to USB too would require Arduino USB-CDC build flags
-(`ARDUINO_USB_CDC_ON_BOOT`/`ARDUINO_USB_MODE`) in CMake — not done.
+both flavors, and `serial_status` mirrors those same lines to USB Serial/JTAG for USB hosts.
 
 ## Source files reviewed
 

--- a/docs/ai/02_firmware_architecture.md
+++ b/docs/ai/02_firmware_architecture.md
@@ -11,7 +11,7 @@
 | BLE processing | `ble_processing.cpp` / `ble_processing.h` | `ble_msg_t`, `ble_msg_id` enum, RTOS queue, command dispatch |
 | State machine | `state_machine.cpp` / `state_machine.h` | `stm_states`, output-pin control, timer |
 | Display | `display.cpp` / `display.h` | SSD1306 rendering per state |
-| Status LED | `status_led.cpp` / `status_led.h` | RGB LED output: green for PLAY, red for stopped output |
+| Status LED | `status_led.cpp` / `status_led.h` | 50% PWM RGB LED output: green for PLAY, red for stopped output |
 | Buzzer | `buzzer.cpp` / `buzzer.h` | Non-blocking 2.7 kHz beep on match-state changes |
 | Functions/util | `functions.cpp` / `functions.h` | MAC string, score/indicator globals, GPIO init, button handling |
 | Assets | `fonts.h`, `images.h` | OLED fonts and boot logo (`RC_logo`) |

--- a/docs/ai/02_firmware_architecture.md
+++ b/docs/ai/02_firmware_architecture.md
@@ -11,6 +11,7 @@
 | BLE processing | `ble_processing.cpp` / `ble_processing.h` | `ble_msg_t`, `ble_msg_id` enum, RTOS queue, command dispatch |
 | State machine | `state_machine.cpp` / `state_machine.h` | `stm_states`, output-pin control, timer |
 | Display | `display.cpp` / `display.h` | SSD1306 rendering per state |
+| Status LED | `status_led.cpp` / `status_led.h` | RGB LED output: green for PLAY, red for stopped output |
 | Buzzer | `buzzer.cpp` / `buzzer.h` | Non-blocking 2.7 kHz beep on match-state changes |
 | Functions/util | `functions.cpp` / `functions.h` | MAC string, score/indicator globals, GPIO init, button handling |
 | Assets | `fonts.h`, `images.h` | OLED fonts and boot logo (`RC_logo`) |
@@ -40,7 +41,7 @@ extern "C" void app_main(void) { initArduino(); module_setup(); while (true) { m
 
 1. `Serial.begin(UART_SPEED)` — `UART_SPEED = 115200`. Used for debug prints only.
 2. `display_init()` — `SSD1306 display(0x3c, I2C_SDA_GPIO, I2C_SCL_GPIO)`, `display.init()`.
-3. `module_init_gpios()` — `OUTPUT1_GPIO`/`OUTPUT2_GPIO` as `OUTPUT`; `BUTTON_GPIO`/`BUTTON2_GPIO` as `INPUT` (no explicit pull configured — see hardware doc); initializes the IO26 passive buzzer.
+3. `module_init_gpios()` — `OUTPUT1_GPIO`/`OUTPUT2_GPIO` as `OUTPUT`; `BUTTON_GPIO`/`BUTTON2_GPIO` as `INPUT` (no explicit pull configured — see hardware doc); initializes the RGB status LED and IO26 passive buzzer.
 4. `stm_init()` — current state stays `STM_INIT`; sets timer to `660000 ms` (see below / [04](04_state_machine.md)).
 5. `ble_start_server()` — creates the message queue, BLE device, server, service, RX/TX characteristics, and starts advertising.
 
@@ -51,8 +52,8 @@ extern "C" void app_main(void) { initArduino(); module_setup(); while (true) { m
 1. **`ble_msg_processing()`** — pops at most **one** message from the queue (`xQueueReceive`
    with timeout `0`) and dispatches it. Non-blocking; returns immediately if empty.
 2. **`stm_update()`** — runs the current state's handler and, on a state change, updates
-   the output pins and starts a short buzzer tone for match states. It also services the
-   non-blocking buzzer timeout.
+   the output pins, mirrors the status to the RGB LED, and starts a short buzzer tone for
+   match states. It also services the non-blocking buzzer timeout.
 3. **`check_disconnect_button()`** — long-press (`DISCONNECT_HOLD_TIME = 5000 ms`) on
    `BUTTON_GPIO` triggers `ble_disconnect()`.
 4. **`check_penalty_button()`** — double-press on `BUTTON_GPIO` **or** `BUTTON2_GPIO`

--- a/docs/ai/05_hardware_mapping.md
+++ b/docs/ai/05_hardware_mapping.md
@@ -99,8 +99,8 @@ Pins below are from `ESP32C5_RCJ_modul_hardware_reference.md` (read pin-by-pin f
 
 | Feature | GPIO / part | Active level / drive | Firmware status |
 |---------|-------------|----------------------|-----------------|
-| RGB LED Red | **IO27** via R9 470 Ω | active **high** | red when robot output is stopped |
-| RGB LED Green | **IO24** via R8 470 Ω | active high | green when robot output is PLAY |
+| RGB LED Red | **IO27** via R9 470 Ω | active **high** | 50% PWM red when robot output is stopped |
+| RGB LED Green | **IO24** via R8 470 Ω | active high | 50% PWM green when robot output is PLAY |
 | RGB LED Blue | **IO23** via R7 470 Ω | active high | initialized off |
 | RGB LED part | LED1 `TC5050RGBF08-3CJH-AF53A` | common-cathode, PWM-capable per channel | — |
 | Buzzer | **IO26** (pin 27) → Q1 (BC817-40) base via R3 470 Ω | drive high; **passive 2.7 kHz** → use PWM ~2.7 kHz | implemented for match-state change beeps |

--- a/docs/ai/05_hardware_mapping.md
+++ b/docs/ai/05_hardware_mapping.md
@@ -9,8 +9,8 @@ The V7/2026 schematic is now in the repo and the pin map is **confirmed**:
   [`ESP32C5_RCJ_modul_hardware_reference.md`](ESP32C5_RCJ_modul_hardware_reference.md).
 
 > ✅ **The firmware (`definitions.h`) matches the V7 hardware for every implemented
-> peripheral** (I2C, the two wired buttons, the two robot outputs, and the buzzer). The
-> RGB LED, third button, and UART1 exist on the board but are **not yet used by firmware** — their
+> peripheral** (I2C, the two wired buttons, the two robot outputs, the RGB LED, and the buzzer). The
+> third button and UART1 exist on the board but are **not yet used by firmware** — their
 > confirmed pins are listed below.
 
 ## Current firmware pin map — ESP32-C5 (active)
@@ -99,9 +99,9 @@ Pins below are from `ESP32C5_RCJ_modul_hardware_reference.md` (read pin-by-pin f
 
 | Feature | GPIO / part | Active level / drive | Firmware status |
 |---------|-------------|----------------------|-----------------|
-| RGB LED Red | **IO27** via R9 470 Ω | active **high** | not implemented |
-| RGB LED Green | **IO24** via R8 470 Ω | active high | not implemented |
-| RGB LED Blue | **IO23** via R7 470 Ω | active high | not implemented |
+| RGB LED Red | **IO27** via R9 470 Ω | active **high** | red when robot output is stopped |
+| RGB LED Green | **IO24** via R8 470 Ω | active high | green when robot output is PLAY |
+| RGB LED Blue | **IO23** via R7 470 Ω | active high | initialized off |
 | RGB LED part | LED1 `TC5050RGBF08-3CJH-AF53A` | common-cathode, PWM-capable per channel | — |
 | Buzzer | **IO26** (pin 27) → Q1 (BC817-40) base via R3 470 Ω | drive high; **passive 2.7 kHz** → use PWM ~2.7 kHz | implemented for match-state change beeps |
 | Third button **B3** | **IO6** = SW2 | active low, 10 kΩ pull-up (R4) | not wired |

--- a/docs/ai/05_hardware_mapping.md
+++ b/docs/ai/05_hardware_mapping.md
@@ -9,8 +9,8 @@ The V7/2026 schematic is now in the repo and the pin map is **confirmed**:
   [`ESP32C5_RCJ_modul_hardware_reference.md`](ESP32C5_RCJ_modul_hardware_reference.md).
 
 > ✅ **The firmware (`definitions.h`) matches the V7 hardware for every implemented
-> peripheral** (I2C, the two wired buttons, the two robot outputs). The RGB LED, buzzer,
-> third button, and UART1 exist on the board but are **not yet used by firmware** — their
+> peripheral** (I2C, the two wired buttons, the two robot outputs, and the buzzer). The
+> RGB LED, third button, and UART1 exist on the board but are **not yet used by firmware** — their
 > confirmed pins are listed below.
 
 ## Current firmware pin map — ESP32-C5 (active)
@@ -103,7 +103,7 @@ Pins below are from `ESP32C5_RCJ_modul_hardware_reference.md` (read pin-by-pin f
 | RGB LED Green | **IO24** via R8 470 Ω | active high | not implemented |
 | RGB LED Blue | **IO23** via R7 470 Ω | active high | not implemented |
 | RGB LED part | LED1 `TC5050RGBF08-3CJH-AF53A` | common-cathode, PWM-capable per channel | — |
-| Buzzer | **IO26** (pin 27) → Q1 (BC817-40) base via R3 470 Ω | drive high; **passive 2.7 kHz** → use PWM ~2.7 kHz | not implemented |
+| Buzzer | **IO26** (pin 27) → Q1 (BC817-40) base via R3 470 Ω | drive high; **passive 2.7 kHz** → use PWM ~2.7 kHz | implemented for match-state change beeps |
 | Third button **B3** | **IO6** = SW2 | active low, 10 kΩ pull-up (R4) | not wired |
 | UART1 RX / TX | **IO4 / IO5** (U3 pins 5–6) | — | not used |
 | GPIO28 | **IO28** on H1 header pin 2 | — | exposed to robot; could sense power if external ckt added |

--- a/docs/ai/09_known_issues_and_open_questions.md
+++ b/docs/ai/09_known_issues_and_open_questions.md
@@ -89,9 +89,9 @@ Residual low-risk verifications (do not block re-pinning) are listed in
 3. Is the **UART robot-to-robot** feature still required/planned, or fully deprecated?
 4. Supercapacitor: pure hardware ride-through, or should firmware **detect/announce** a power
    dip (LED/buzzer/BLE notification, safe-state)?
-5. Desired **RGB LED** semantics per state/event and any future buzzer patterns (the tables in
-   [06](06_display_and_user_feedback.md) are guesses). Pins are now known (RGB R/G/B =
-   IO27/IO24/IO23; buzzer = IO26).
+5. Desired future **RGB LED** patterns beyond PLAY=green and stopped=red, plus any future
+   buzzer patterns (the tables in [06](06_display_and_user_feedback.md) are guesses). Pins
+   are now known (RGB R/G/B = IO27/IO24/IO23; buzzer = IO26).
 6. Intended role of the **third button** B3 = **IO6 / SW2** (menu? channel? manual play/stop?).
 7. Purpose of the **`660000 ms`** init timer — keep, fix, or remove?
 8. Should the `.ino` entry point be retired in favor of the IDF `main/` path?

--- a/docs/ai/09_known_issues_and_open_questions.md
+++ b/docs/ai/09_known_issues_and_open_questions.md
@@ -89,7 +89,7 @@ Residual low-risk verifications (do not block re-pinning) are listed in
 3. Is the **UART robot-to-robot** feature still required/planned, or fully deprecated?
 4. Supercapacitor: pure hardware ride-through, or should firmware **detect/announce** a power
    dip (LED/buzzer/BLE notification, safe-state)?
-5. Desired **RGB LED** and **buzzer** semantics per state/event (the tables in
+5. Desired **RGB LED** semantics per state/event and any future buzzer patterns (the tables in
    [06](06_display_and_user_feedback.md) are guesses). Pins are now known (RGB R/G/B =
    IO27/IO24/IO23; buzzer = IO26).
 6. Intended role of the **third button** B3 = **IO6 / SW2** (menu? channel? manual play/stop?).

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -38,11 +38,12 @@ while waiting for a connection).
   for USB-C logging during development.
 - Target chip: **ESP32-C5**, ESP-IDF **v5.5.4**, `espressif/arduino-esp32` `^3.3.0`, **NimBLE**.
 - Runs on the new ESP32-C5 hardware in **legacy-compatibility mode**: same behavior as the
-  old module, only with remapped pins. UART/`Serial` is still used (debug prints + legacy).
+  old module, only with remapped pins. UART/`Serial` is still used and the PLAY/STOP status
+  is mirrored to USB Serial/JTAG for USB hosts.
 - New hardware (silkscreen **"V7 2026"**, branding "robofuze") adds RGB LED, buzzer,
   supercapacitor backup, three buttons, ON/OFF switch, and USB-C direct programming.
-  **None of the RGB LED / buzzer / 3rd-button / supercap features are implemented in
-  firmware yet.**
+  The buzzer now gives a short beep on match-state changes; RGB LED and third-button
+  behavior are still future work. The supercap is hardware-only.
 - Release/flashing is automated: Git tag → GitHub Actions → GitHub Release + GitHub Pages
   web flasher (Web Serial / esptool-js, ESP32-C5 USB reset path).
 

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -42,7 +42,7 @@ while waiting for a connection).
   is mirrored to USB Serial/JTAG for USB hosts.
 - New hardware (silkscreen **"V7 2026"**, branding "robofuze") adds RGB LED, buzzer,
   supercapacitor backup, three buttons, ON/OFF switch, and USB-C direct programming.
-  The RGB LED now shows PLAY as green and stopped output as red, and the buzzer gives a
+  The RGB LED now shows PLAY as dimmed green and stopped output as dimmed red, and the buzzer gives a
   short beep on match-state changes. Third-button behavior is still future work. The
   supercap is hardware-only.
 - Release/flashing is automated: Git tag → GitHub Actions → GitHub Release + GitHub Pages

--- a/docs/ai/README.md
+++ b/docs/ai/README.md
@@ -42,8 +42,9 @@ while waiting for a connection).
   is mirrored to USB Serial/JTAG for USB hosts.
 - New hardware (silkscreen **"V7 2026"**, branding "robofuze") adds RGB LED, buzzer,
   supercapacitor backup, three buttons, ON/OFF switch, and USB-C direct programming.
-  The buzzer now gives a short beep on match-state changes; RGB LED and third-button
-  behavior are still future work. The supercap is hardware-only.
+  The RGB LED now shows PLAY as green and stopped output as red, and the buzzer gives a
+  short beep on match-state changes. Third-button behavior is still future work. The
+  supercap is hardware-only.
 - Release/flashing is automated: Git tag → GitHub Actions → GitHub Release + GitHub Pages
   web flasher (Web Serial / esptool-js, ESP32-C5 USB reset path).
 

--- a/firmware/RCj_comm_module/RCj_comm_module.ino
+++ b/firmware/RCj_comm_module/RCj_comm_module.ino
@@ -5,9 +5,11 @@
 #include "state_machine.h"
 #include "ble_processing.h"
 #include "display.h"
+#include "serial_status.h"
 
 void setup() {
     Serial.begin(UART_SPEED);
+    serial_status_init();
     
     // Init display
     display_init();

--- a/firmware/RCj_comm_module/buzzer.cpp
+++ b/firmware/RCj_comm_module/buzzer.cpp
@@ -1,0 +1,42 @@
+#include "buzzer.h"
+
+#include <Arduino.h>
+
+#include "definitions.h"
+
+static bool buzzer_ready = false;
+static bool buzzer_active = false;
+static uint32_t buzzer_stop_time = 0;
+
+void buzzer_init()
+{
+    pinMode(BUZZER_GPIO, OUTPUT);
+    digitalWrite(BUZZER_GPIO, LOW);
+
+    buzzer_ready = ledcAttach(BUZZER_GPIO, BUZZER_FREQUENCY_HZ, 10);
+
+    if (buzzer_ready) {
+        ledcWriteTone(BUZZER_GPIO, 0);
+    }
+}
+
+void buzzer_notify_state_change()
+{
+    if (!buzzer_ready) {
+        return;
+    }
+
+    ledcWriteTone(BUZZER_GPIO, BUZZER_FREQUENCY_HZ);
+    buzzer_stop_time = millis() + BUZZER_DURATION_MS;
+    buzzer_active = true;
+}
+
+void buzzer_update()
+{
+    if (!buzzer_active || (int32_t)(millis() - buzzer_stop_time) < 0) {
+        return;
+    }
+
+    ledcWriteTone(BUZZER_GPIO, 0);
+    buzzer_active = false;
+}

--- a/firmware/RCj_comm_module/buzzer.h
+++ b/firmware/RCj_comm_module/buzzer.h
@@ -1,0 +1,8 @@
+#ifndef BUZZER_H
+#define BUZZER_H
+
+void buzzer_init();
+void buzzer_notify_state_change();
+void buzzer_update();
+
+#endif // BUZZER_H

--- a/firmware/RCj_comm_module/definitions.h
+++ b/firmware/RCj_comm_module/definitions.h
@@ -36,6 +36,11 @@
 #define OUTPUT1_GPIO    9
 #define OUTPUT2_GPIO    8
 
+// RGB status LED
+#define RGB_LED_RED_GPIO        27
+#define RGB_LED_GREEN_GPIO      24
+#define RGB_LED_BLUE_GPIO       23
+
 // Passive buzzer
 #define BUZZER_GPIO             26
 #define BUZZER_FREQUENCY_HZ     2700

--- a/firmware/RCj_comm_module/definitions.h
+++ b/firmware/RCj_comm_module/definitions.h
@@ -40,6 +40,9 @@
 #define RGB_LED_RED_GPIO        27
 #define RGB_LED_GREEN_GPIO      24
 #define RGB_LED_BLUE_GPIO       23
+#define RGB_LED_PWM_HZ          1000
+#define RGB_LED_PWM_RESOLUTION  8
+#define RGB_LED_PWM_DUTY        128
 
 // Passive buzzer
 #define BUZZER_GPIO             26

--- a/firmware/RCj_comm_module/definitions.h
+++ b/firmware/RCj_comm_module/definitions.h
@@ -36,4 +36,9 @@
 #define OUTPUT1_GPIO    9
 #define OUTPUT2_GPIO    8
 
+// Passive buzzer
+#define BUZZER_GPIO             26
+#define BUZZER_FREQUENCY_HZ     2700
+#define BUZZER_DURATION_MS      80
+
 #endif // DEFINITIONS_H

--- a/firmware/RCj_comm_module/functions.cpp
+++ b/firmware/RCj_comm_module/functions.cpp
@@ -8,6 +8,7 @@
 #include "definitions.h"
 #include "ble.h"
 #include "ble_processing.h"
+#include "buzzer.h"
 #include "functions.h"
 
 #define DEBOUNCE_DELAY 50 //ms
@@ -71,6 +72,7 @@ void module_init_gpios() {
     pinMode(OUTPUT2_GPIO, OUTPUT);
     pinMode(BUTTON_GPIO, INPUT);
     pinMode(BUTTON2_GPIO, INPUT);
+    buzzer_init();
 }
 
 void check_disconnect_button() {

--- a/firmware/RCj_comm_module/functions.cpp
+++ b/firmware/RCj_comm_module/functions.cpp
@@ -10,6 +10,7 @@
 #include "ble_processing.h"
 #include "buzzer.h"
 #include "functions.h"
+#include "status_led.h"
 
 #define DEBOUNCE_DELAY 50 //ms
 #define DOUBLE_PRESS_MAX_DELAY 1000 //ms
@@ -72,6 +73,7 @@ void module_init_gpios() {
     pinMode(OUTPUT2_GPIO, OUTPUT);
     pinMode(BUTTON_GPIO, INPUT);
     pinMode(BUTTON2_GPIO, INPUT);
+    status_led_init();
     buzzer_init();
 }
 

--- a/firmware/RCj_comm_module/main/CMakeLists.txt
+++ b/firmware/RCj_comm_module/main/CMakeLists.txt
@@ -8,6 +8,7 @@ idf_component_register(
         "app_main.cpp"
         "${APP_DIR}/ble.cpp"
         "${APP_DIR}/ble_processing.cpp"
+        "${APP_DIR}/buzzer.cpp"
         "${APP_DIR}/display.cpp"
         "${APP_DIR}/functions.cpp"
         "${APP_DIR}/serial_status.cpp"

--- a/firmware/RCj_comm_module/main/CMakeLists.txt
+++ b/firmware/RCj_comm_module/main/CMakeLists.txt
@@ -10,6 +10,7 @@ idf_component_register(
         "${APP_DIR}/ble_processing.cpp"
         "${APP_DIR}/display.cpp"
         "${APP_DIR}/functions.cpp"
+        "${APP_DIR}/serial_status.cpp"
         "${APP_DIR}/state_machine.cpp"
         "${OLED_DIR}/OLEDDisplay.cpp"
         "${OLED_DIR}/OLEDDisplayUi.cpp"
@@ -34,6 +35,7 @@ idf_component_register(
         "${QRCODE_OLED_DIR}"
     REQUIRES
         espressif__arduino-esp32
+        esp_driver_usb_serial_jtag
 )
 
 target_compile_options(${COMPONENT_LIB} PRIVATE -Wno-error=overloaded-virtual)

--- a/firmware/RCj_comm_module/main/CMakeLists.txt
+++ b/firmware/RCj_comm_module/main/CMakeLists.txt
@@ -12,6 +12,7 @@ idf_component_register(
         "${APP_DIR}/display.cpp"
         "${APP_DIR}/functions.cpp"
         "${APP_DIR}/serial_status.cpp"
+        "${APP_DIR}/status_led.cpp"
         "${APP_DIR}/state_machine.cpp"
         "${OLED_DIR}/OLEDDisplay.cpp"
         "${OLED_DIR}/OLEDDisplayUi.cpp"

--- a/firmware/RCj_comm_module/main/app_main.cpp
+++ b/firmware/RCj_comm_module/main/app_main.cpp
@@ -5,11 +5,13 @@
 #include "ble_processing.h"
 #include "display.h"
 #include "functions.h"
+#include "serial_status.h"
 #include "state_machine.h"
 
 static void module_setup()
 {
     Serial.begin(UART_SPEED);
+    serial_status_init();
 
     display_init();
     module_init_gpios();

--- a/firmware/RCj_comm_module/serial_status.cpp
+++ b/firmware/RCj_comm_module/serial_status.cpp
@@ -1,0 +1,31 @@
+#include "serial_status.h"
+
+#include <Arduino.h>
+#include <string.h>
+
+#include "driver/usb_serial_jtag.h"
+
+static bool usb_serial_jtag_ready = false;
+
+void serial_status_init()
+{
+    if (usb_serial_jtag_is_driver_installed()) {
+        usb_serial_jtag_ready = true;
+        return;
+    }
+
+    usb_serial_jtag_driver_config_t usb_config = USB_SERIAL_JTAG_DRIVER_CONFIG_DEFAULT();
+    usb_serial_jtag_ready = usb_serial_jtag_driver_install(&usb_config) == ESP_OK;
+}
+
+void serial_status_println(const char *message)
+{
+    Serial.println(message);
+
+    if (!usb_serial_jtag_ready) {
+        return;
+    }
+
+    usb_serial_jtag_write_bytes(message, strlen(message), 0);
+    usb_serial_jtag_write_bytes("\r\n", 2, 0);
+}

--- a/firmware/RCj_comm_module/serial_status.h
+++ b/firmware/RCj_comm_module/serial_status.h
@@ -1,0 +1,7 @@
+#ifndef SERIAL_STATUS_H
+#define SERIAL_STATUS_H
+
+void serial_status_init();
+void serial_status_println(const char *message);
+
+#endif // SERIAL_STATUS_H

--- a/firmware/RCj_comm_module/state_machine.cpp
+++ b/firmware/RCj_comm_module/state_machine.cpp
@@ -12,6 +12,7 @@
 #include "buzzer.h"
 #include "display.h"
 #include "serial_status.h"
+#include "status_led.h"
 #include "state_machine.h"
 
 static stm_states current_state = STM_INIT;
@@ -39,10 +40,12 @@ static void update_output_satet() {
     if (robot_play) {
         digitalWrite(OUTPUT1_GPIO, HIGH);
         digitalWrite(OUTPUT2_GPIO, HIGH);
+        status_led_set_play(true);
         serial_status_println("PLAY");
     } else {
         digitalWrite(OUTPUT1_GPIO, LOW);
         digitalWrite(OUTPUT2_GPIO, LOW);
+        status_led_set_play(false);
         serial_status_println("STOP");
     }
 }

--- a/firmware/RCj_comm_module/state_machine.cpp
+++ b/firmware/RCj_comm_module/state_machine.cpp
@@ -10,6 +10,7 @@
 
 #include "definitions.h"
 #include "display.h"
+#include "serial_status.h"
 #include "state_machine.h"
 
 static stm_states current_state = STM_INIT;
@@ -29,11 +30,11 @@ static void update_output_satet() {
     if (robot_play) {
         digitalWrite(OUTPUT1_GPIO, HIGH);
         digitalWrite(OUTPUT2_GPIO, HIGH);
-        Serial.println("PLAY");
+        serial_status_println("PLAY");
     } else {
         digitalWrite(OUTPUT1_GPIO, LOW);
         digitalWrite(OUTPUT2_GPIO, LOW);
-        Serial.println("STOP");
+        serial_status_println("STOP");
     }
 }
 

--- a/firmware/RCj_comm_module/state_machine.cpp
+++ b/firmware/RCj_comm_module/state_machine.cpp
@@ -9,6 +9,7 @@
 #include "esp_err.h"
 
 #include "definitions.h"
+#include "buzzer.h"
 #include "display.h"
 #include "serial_status.h"
 #include "state_machine.h"
@@ -17,6 +18,14 @@ static stm_states current_state = STM_INIT;
 static bool state_changed = false;
 static bool robot_play = false;
 static uint32_t timer_stop = 0;
+
+static bool is_match_state(stm_states state) {
+    return state == STM_PLAY ||
+           state == STM_STOP ||
+           state == STM_DAMAGE ||
+           state == STM_HALF_TIME ||
+           state == STM_GAME_OVER;
+}
 
 static uint16_t get_remaining_time() {
     uint32_t current_time = millis();
@@ -136,9 +145,14 @@ int8_t stm_update() {
 
     if (state_changed) {
         update_output_satet();
+        if (is_match_state(current_state)) {
+            buzzer_notify_state_change();
+        }
     }
 
     if (change_noted) state_changed = false;
+
+    buzzer_update();
 
     return ESP_OK;
 }

--- a/firmware/RCj_comm_module/status_led.cpp
+++ b/firmware/RCj_comm_module/status_led.cpp
@@ -1,0 +1,23 @@
+#include "status_led.h"
+
+#include <Arduino.h>
+
+#include "definitions.h"
+
+void status_led_init()
+{
+    pinMode(RGB_LED_RED_GPIO, OUTPUT);
+    pinMode(RGB_LED_GREEN_GPIO, OUTPUT);
+    pinMode(RGB_LED_BLUE_GPIO, OUTPUT);
+
+    digitalWrite(RGB_LED_RED_GPIO, LOW);
+    digitalWrite(RGB_LED_GREEN_GPIO, LOW);
+    digitalWrite(RGB_LED_BLUE_GPIO, LOW);
+}
+
+void status_led_set_play(bool play)
+{
+    digitalWrite(RGB_LED_RED_GPIO, play ? LOW : HIGH);
+    digitalWrite(RGB_LED_GREEN_GPIO, play ? HIGH : LOW);
+    digitalWrite(RGB_LED_BLUE_GPIO, LOW);
+}

--- a/firmware/RCj_comm_module/status_led.cpp
+++ b/firmware/RCj_comm_module/status_led.cpp
@@ -6,18 +6,18 @@
 
 void status_led_init()
 {
-    pinMode(RGB_LED_RED_GPIO, OUTPUT);
-    pinMode(RGB_LED_GREEN_GPIO, OUTPUT);
-    pinMode(RGB_LED_BLUE_GPIO, OUTPUT);
+    ledcAttach(RGB_LED_RED_GPIO, RGB_LED_PWM_HZ, RGB_LED_PWM_RESOLUTION);
+    ledcAttach(RGB_LED_GREEN_GPIO, RGB_LED_PWM_HZ, RGB_LED_PWM_RESOLUTION);
+    ledcAttach(RGB_LED_BLUE_GPIO, RGB_LED_PWM_HZ, RGB_LED_PWM_RESOLUTION);
 
-    digitalWrite(RGB_LED_RED_GPIO, LOW);
-    digitalWrite(RGB_LED_GREEN_GPIO, LOW);
-    digitalWrite(RGB_LED_BLUE_GPIO, LOW);
+    ledcWrite(RGB_LED_RED_GPIO, 0);
+    ledcWrite(RGB_LED_GREEN_GPIO, 0);
+    ledcWrite(RGB_LED_BLUE_GPIO, 0);
 }
 
 void status_led_set_play(bool play)
 {
-    digitalWrite(RGB_LED_RED_GPIO, play ? LOW : HIGH);
-    digitalWrite(RGB_LED_GREEN_GPIO, play ? HIGH : LOW);
-    digitalWrite(RGB_LED_BLUE_GPIO, LOW);
+    ledcWrite(RGB_LED_RED_GPIO, play ? 0 : RGB_LED_PWM_DUTY);
+    ledcWrite(RGB_LED_GREEN_GPIO, play ? RGB_LED_PWM_DUTY : 0);
+    ledcWrite(RGB_LED_BLUE_GPIO, 0);
 }

--- a/firmware/RCj_comm_module/status_led.h
+++ b/firmware/RCj_comm_module/status_led.h
@@ -1,0 +1,7 @@
+#ifndef STATUS_LED_H
+#define STATUS_LED_H
+
+void status_led_init();
+void status_led_set_play(bool play);
+
+#endif // STATUS_LED_H


### PR DESCRIPTION
## Motivation

We were wondering why the soccer communication module cannot currently be read through the easiest-to-use port available today: the USB-C port. Therefore, we decided to implement this feature.

We would be very happy if this feature gets adopted, as it would simplify the integration of the module for new soccer teams. With the USB-C interface, a true plug-and-play setup can be achieved.

## Summary

This adds USB serial output for the module's PLAY/STOP status changes.

The existing behavior is preserved:

- OUT1/OUT2 still switch HIGH for PLAY and LOW for STOP
- UART0 still prints PLAY/STOP for robots using the U3 TX0 header

New behavior:

- The ESP32-C5 USB Serial/JTAG port also prints PLAY or STOP
- This allows a Raspberry Pi or other USB host to detect match state changes over the module's USB-C port

## Verification

Built successfully with ESP-IDF:

```sh
  idf.py build

  USB serial can be checked on Linux with:

  stty -F /dev/ttyACM0 115200 raw -echo
  cat /dev/ttyACM0

  Expected output when the referee app changes state:

  PLAY
  STOP